### PR TITLE
Accept generateResource flag when updating roles.

### DIFF
--- a/lib/identity.js
+++ b/lib/identity.js
@@ -75,7 +75,11 @@ api.insert = function(actor, identity, callback) {
       for(var i = 0; i < roles.length; ++i) {
         var role = roles[i];
         if(role.generateResource === 'id') {
-          role.resource = [identity.id];
+          if(!role.resource) {
+            role.resource = [identity.id];
+          } else if(role.resource.indexOf(identity.id) === -1) {
+            role.resource.push(identity.id);
+          }
           delete role.generateResource;
         } else if(role.generateResource) {
           // unknown
@@ -286,6 +290,26 @@ api.setRoles = function(actor, identity, callback) {
         actor, PERMISSIONS.IDENTITY_ADMIN, {resource: identity}, callback);
     },
     function(callback) {
+      // generate resource role resources
+      var roles = identity.sysResourceRole = identity.sysResourceRole || [];
+      for(var i = 0; i < roles.length; ++i) {
+        var role = roles[i];
+        if(role.generateResource === 'id') {
+          // Append identity.id to the given resource list,
+          // if it doesn't already exist
+          if(!role.resource) {
+            role.resource = [identity.id];
+          } else if(role.resource.indexOf(identity.id) === -1) {
+            role.resource.push(identity.id);
+          }
+          delete role.generateResource;
+        } else if(role.generateResource) {
+          // unknown
+          return callback(new BedrockError(
+            'Could not set roles.',
+            'InvalidResourceRole', {sysResourceRole: role}));
+        }
+      }
       database.collections.identity.update(
         {id: database.hash(identity.id)},
         {$set: {'identity.sysResourceRole': identity.sysResourceRole}},


### PR DESCRIPTION
generateResource is a flag that you can attach to roles
inside an identity when creating it, the flag basically
tells the api to restrict that role to only the identity's ID.
This extends this functionality to allow you to pass the flag
in on identity update as well.
