### PR TITLE
Model fields

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,20 @@ require('bedrock-permission');
 
 config.identity = {};
 
+/**
+ * An extendable list of accepted fields for each identity model
+ */
+config.identity.fields = [
+  'identity.description',
+  'identity.image',
+  'identity.label',
+  'identity.sysGravatarType',
+  'identity.sysImageType',
+  'identity.sysPublic',
+  'identity.sysSigningKey',
+  'identity.url'
+];
+
 var constants = config.constants;
 
 /**

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -7,6 +7,7 @@ var async = require('async');
 var bedrock = require('bedrock');
 var config = bedrock.config;
 var brPermission = require('bedrock-permission');
+var config = bedrock.config;
 var database = require('bedrock-mongodb');
 var BedrockError = bedrock.util.BedrockError;
 
@@ -234,18 +235,10 @@ api.update = function(actor, identity, options, callback) {
         actor, PERMISSIONS.IDENTITY_EDIT, {resource: identity}, callback);
     },
     function(callback) {
-      // build a database update
+      // Build a database update from the configured list of accepted fields.
+      var permittedFields = config.identity.fields;
       var update = database.buildUpdate(identity, 'identity', {
-        include: [
-          'identity.description',
-          'identity.image',
-          'identity.label',
-          'identity.sysGravatarType',
-          'identity.sysImageType',
-          'identity.sysPublic',
-          'identity.sysSigningKey',
-          'identity.url'
-        ]
+        include: permittedFields
       });
       database.collections.identity.update(
         {id: database.hash(identity.id)},


### PR DESCRIPTION
https://github.com/digitalbazaar/bedrock-identity-rest/pull/3 and https://github.com/digitalbazaar/bedrock-issuer/pull/5 depend on this PR.

The only place we've previously checked for allowable fields was in the update call -- weird that we don't evaluate allowable fields on creation as well, any ideas on why that is?
