### PR TITLE
Add options parameter to the get API and tests.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,17 +124,29 @@ api.insert = function(actor, identity, callback) {
  *
  * @param actor the Identity performing the action.
  * @param id the ID of the Identity to retrieve.
+ * @param [options] the options to use.
+ *          [active] true to only get an active identity.  A request for a
+ *            non-active identity will return a NotFound error.
  * @param callback(err, identity, meta) called once the operation completes.
  */
-api.get = function(actor, id, callback) {
+api.get = function(actor, id, options, callback) {
+  // handle args
+  if(typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+  options = options || {};
+  var query = {id: database.hash(id)};
+  if(options.active) {
+    query['identity.sysStatus'] = 'active';
+  }
   async.waterfall([
     function(callback) {
       api.checkPermission(
         actor, PERMISSIONS.IDENTITY_ACCESS, {resource: id}, callback);
     },
     function(callback) {
-      database.collections.identity.findOne(
-        {id: database.hash(id)}, {}, callback);
+      database.collections.identity.findOne(query, {}, callback);
     },
     function(record, callback) {
       if(!record) {

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -163,6 +163,27 @@ describe('bedrock-identity', function() {
           }]
         }, done);
       });
+      it('returns not found error when active option is specified',
+        function(done) {
+          var testIdentity = actors['will-b-disabled'];
+          async.auto({
+            deleteIdentity: function(callback) {
+              brIdentity.setStatus(null, testIdentity.id, 'deleted', callback);
+            },
+            getIdentity: ['deleteIdentity', function(callback) {
+              brIdentity
+                .get(null, testIdentity.id, {active: true}, function(err, i) {
+                  should.exist(err);
+                  should.not.exist(i);
+                  err.name.should.equal('NotFound');
+                  callback();
+                });
+            }],
+            activateIdentity: ['getIdentity', function(callback) {
+              brIdentity.setStatus(null, testIdentity.id, 'active', callback);
+            }]
+          }, done);
+        });
     }); // end null actor
     describe('regular user', function() {
       it('should be able to access itself', function(done) {


### PR DESCRIPTION
if `options.active` is truthy, `get()` will only return an active identity and will return a `NotFound` error otherwise.
