### PR TITLE
Implement `generateResource` API.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,25 @@ bedrock.events.on('bedrock-mongodb.ready', function init(callback) {
 });
 
 /**
+ * Inserts a specified ID into a role's resource restriction array.
+ *
+ * @param role the role to transform.
+ * @param id the ID to insert into the resource array.
+ *
+ * @return role the transformed role.
+ */
+api.generateResource = function(role, id) {
+  role = bedrock.util.clone(role);
+  if(!role.resource) {
+    role.resource = [id];
+  } else if(role.resource.indexOf(id) === -1) {
+    role.resource.push(id);
+  }
+  delete role.generateResource;
+  return role;
+};
+
+/**
  * Inserts a new Identity. The Identity must contain `id`.
  *
  * @param actor the Identity performing the action.
@@ -74,12 +93,7 @@ api.insert = function(actor, identity, callback) {
       for(var i = 0; i < roles.length; ++i) {
         var role = roles[i];
         if(role.generateResource === 'id') {
-          if(!role.resource) {
-            role.resource = [identity.id];
-          } else if(role.resource.indexOf(identity.id) === -1) {
-            role.resource.push(identity.id);
-          }
-          delete role.generateResource;
+          roles[i] = api.generateResource(role, identity.id);
         } else if(role.generateResource) {
           // unknown
           return callback(new BedrockError(


### PR DESCRIPTION
Fixes #10.

Previously added tests that ensure proper `generateResource` operation within the `insert` API.