### PR TITLE
Only allow specific identity properties.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,12 +124,27 @@ bedrock.events.on(
  * @param identity the Identity containing at least the minimum required data.
  * @param [meta] optional meta information to include.
  *
- * @return a Promise that resolves to the new record.
+ * @return {Promise} the new record.
  */
 api.insert = brCallbackify(async ({actor, identity, meta}) => {
   assert.object(identity, 'identity');
   assert.string(identity.id, 'identity.id');
   assert.optionalString(identity.owner, 'identity.owner');
+
+  // select only allowed identity properties. It is particularly important that
+  // `sysResoureRole` is excluded in case someone upgrades to v5.x+ without
+  // updating their code.
+  identity = _.pick(identity, [
+    'id',
+    'description',
+    'email',
+    'label',
+    'memberOf',
+    'owner',
+    'sysSlug',
+    'type',
+    'url',
+  ]);
 
   meta = Object.assign({}, meta, {status: 'active'});
   // ensure resource roles are an array


### PR DESCRIPTION
Was the `insert` API designed to allow arbitrary identity properties?  If so, I'll need to come at this from another angle.

This patch will be applied to 6.x as well.